### PR TITLE
fix: exclude e2e tests from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: uv sync --dev
 
       - name: Run test suite
-        run: uv run pytest
+        run: uv run pytest --ignore=tests/e2e
 
       - name: Smoke test web UI import
         run: uv run python -c "from gow_optimizer.web import app; print('Web app imported successfully')"


### PR DESCRIPTION
## Problema

La CI (#51, #52) fallisce dopo il merge di #26 perché `uv run pytest` raccoglie anche `tests/e2e/` che:
1. Importa `playwright.sync_api` al top-level — non disponibile senza `playwright install`
2. Richiede i CSV data files reali (`data/all_pieces.csv`, `data/all_weapons.csv`) che sono gitignored

## Fix

Aggiunto `--ignore=tests/e2e` al comando pytest nel workflow CI.

I test e2e (96 test) restano disponibili per esecuzione locale. I 101 test unitari passano in ~7s.

## Verifica
```bash
uv run pytest --ignore=tests/e2e --tb=short -q
# 101 passed in 7.08s
```

## Summary by Sourcery

CI:
- Update the CI workflow to run pytest with --ignore=tests/e2e so only unit tests execute in CI.